### PR TITLE
fix: enforce proper JSON unmarshal per API contract

### DIFF
--- a/sdk/template.go
+++ b/sdk/template.go
@@ -8,10 +8,10 @@ import (
 
 // Template is a Sendgrid transactional template.
 type Template struct {
-	ID         string            `json:"id,omitempty"`
-	Name       string            `json:"name,omitempty"`
-	Generation string            `json:"generation,omitempty"`
-	UpdatedAt  string            `json:"updated_at,omitempty"`
+	ID         string            `json:"id"`
+	Name       string            `json:"name"`
+	Generation string            `json:"generation"`
+	UpdatedAt  string            `json:"updated_at"`
 	Versions   []TemplateVersion `json:"versions,omitempty"`
 	Warnings   []string          `json:"warnings,omitempty"`
 }


### PR DESCRIPTION
Sendgrid's [API contract for the templates endpoint](https://docs.sendgrid.com/api-reference/transactional-templates/create-a-transactional-template) mention that those four fields are required. Letting them pass empty result in hard to debug errors down the chain.

We're seeing intermittent errors with this simple terraform:

```terraform
resource "sendgrid_template" "cognito" {
  name       = "pascal-test-intermittent"
  generation = "dynamic"
}

resource "sendgrid_template_version" "cognito" {
  active       = 1
  html_content = "<html><body></body></html>"
  name         = "current"
  subject      = "just a test"
  template_id  = sendgrid_template.cognito.id
}
```

Where the error is:

```
│ Error: a template ID is required
│ 
│   with sendgrid_template_version.cognito,
│   on cognito-sender.tf line 25, in resource "sendgrid_template_version" "cognito":
│   25: resource "sendgrid_template_version" "cognito" {
│ 
```

Which, well, the template ID should never be empty at this point, but the provider code allows it through and we're unable to see the original error, if any. If there's no template ID in the response, it should be the `sendgrid_template` that fails, not the subsequent `sendgrid_template_version`.